### PR TITLE
Change LoggerAdapter to record start and end times on TraceLeave...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Tracer 1.1.0
+Tracer 1.1.1
 ======
 
 Tracing and logging rewriter using Fody. It adds trace enter and trace leave log entries for the methods specified. Such calls include incoming and outgoing arguments as well as time spent in the method. It also rewrites static log entries to properly configured log calls. Tracer is the rewriter core on which one of the specific adapters like Tracer.Log4Net is built uppon. Creating custom adapters for your specific needs is very easy. 
@@ -27,6 +27,8 @@ Version History for Tracer:
     - Trace leave now logs when a method is exited with an exception
     - Bug fix on static log rewrites
     - Tracer now creates verifiable code
+* 1.1.1
+    - Fixed static log rewrite for constructors and closures/lambdas
 
 Version History for Tracer.Log4Net:
 ---

--- a/TestApplication/MyApplication.cs
+++ b/TestApplication/MyApplication.cs
@@ -92,6 +92,24 @@ namespace TestApplication
             Log.FatalFormat("A{0}-B{1}-C{2}", 1, 2, 3);
             Log.FatalFormat("A{0}-B{1}-C{2}-D{3}", 1, 2, 3, 4);
             Log.FatalFormat(new CultureInfo("en-us"), "A{0}-B{1}-C{2}-D{3}", 1, 2, 3, 4);
+
+            //closure
+            int idx = 1;
+            Action act = () =>
+            {
+                idx++;
+                Log.Debug("Closure log");
+            };
+
+            act();
+
+            //lambda w/out closure
+            Action act2 = () =>
+            {
+                Log.Debug("No closure log");
+            };
+
+            act2();
         }
 
         [TraceOn]

--- a/Tracer.Fody.Tests/TestBase.cs
+++ b/Tracer.Fody.Tests/TestBase.cs
@@ -166,11 +166,19 @@ namespace Tracer.Fody.Tests
 
         #region Various trace logging filters for testing
 
-        protected class NullTraceLoggingFilter : ITraceLoggingFilter
+        protected class AllTraceLoggingFilter : ITraceLoggingFilter
         {
             public bool ShouldAddTrace(MethodDefinition definition)
             {
                 return true;
+            }
+        }
+
+        protected class NoTraceLoggingFilter : ITraceLoggingFilter
+        {
+            public bool ShouldAddTrace(MethodDefinition definition)
+            {
+                return false;
             }
         }
 

--- a/Tracer.Fody.Tests/TraceTests/ExceptionTests.cs
+++ b/Tracer.Fody.Tests/TraceTests/ExceptionTests.cs
@@ -37,7 +37,7 @@ namespace Tracer.Fody.Tests.TraceTests
                 }
             ";
 
-            var result = this.RunTest(code, new NullTraceLoggingFilter(), "First.MyClass::Main");
+            var result = this.RunTest(code, new AllTraceLoggingFilter(), "First.MyClass::Main");
             result.Count.Should().Be(4);
             result.ElementAt(0).ShouldBeTraceEnterInto("First.MyClass::Main");
             result.ElementAt(1).ShouldBeTraceEnterInto("First.MyClass::MyStatic");
@@ -72,7 +72,7 @@ namespace Tracer.Fody.Tests.TraceTests
                 }
             ";
 
-            var result = this.RunTest(code, new NullTraceLoggingFilter(), "First.MyClass::Main");
+            var result = this.RunTest(code, new AllTraceLoggingFilter(), "First.MyClass::Main");
             result.Count.Should().Be(4);
             result.ElementAt(0).ShouldBeTraceEnterInto("First.MyClass::Main");
             result.ElementAt(1).ShouldBeTraceEnterInto("First.MyClass::Run");
@@ -110,7 +110,7 @@ namespace Tracer.Fody.Tests.TraceTests
                 }
             ";
 
-            var result = this.RunTest(code, new NullTraceLoggingFilter(), "First.MyClass::Main");
+            var result = this.RunTest(code, new AllTraceLoggingFilter(), "First.MyClass::Main");
             result.Count.Should().Be(6);
             result.ElementAt(0).ShouldBeTraceEnterInto("First.MyClass::Main");
             result.ElementAt(1).ShouldBeTraceEnterInto("First.MyClass::MyStatic");
@@ -148,7 +148,7 @@ namespace Tracer.Fody.Tests.TraceTests
                 }
             ";
 
-            var result = this.RunTest(code, new NullTraceLoggingFilter(), "First.MyClass::Main");
+            var result = this.RunTest(code, new AllTraceLoggingFilter(), "First.MyClass::Main");
             result.Count.Should().Be(6);
             result.ElementAt(0).ShouldBeTraceEnterInto("First.MyClass::Main");
             result.ElementAt(1).ShouldBeTraceEnterInto("First.MyClass::Run", "inp", "1");

--- a/Tracer.Fody.Tests/TraceTests/NoParamsNoRetvalTests.cs
+++ b/Tracer.Fody.Tests/TraceTests/NoParamsNoRetvalTests.cs
@@ -29,7 +29,7 @@ namespace Tracer.Fody.Tests.TraceTests
                 }
             ";
 
-            var result = this.RunTest(code, new NullTraceLoggingFilter(), "First.MyClass::Main");
+            var result = this.RunTest(code, new AllTraceLoggingFilter(), "First.MyClass::Main");
             result.Count.Should().Be(2);
             result.ElementAt(0).ShouldBeTraceEnterInto("First.MyClass::Main");
             result.ElementAt(1).ShouldBeTraceLeaveFrom("First.MyClass::Main");
@@ -60,7 +60,7 @@ namespace Tracer.Fody.Tests.TraceTests
                 }
             ";
 
-            var result = this.RunTest(code, new NullTraceLoggingFilter(), "First.MyClass::Main");
+            var result = this.RunTest(code, new AllTraceLoggingFilter(), "First.MyClass::Main");
             result.Count.Should().Be(4);
             result.ElementAt(0).ShouldBeTraceEnterInto("First.MyClass::Main");
             result.ElementAt(1).ShouldBeTraceEnterInto("First.MyClass::Run");

--- a/Tracer.Fody.Tests/TraceTests/SpecialTests.cs
+++ b/Tracer.Fody.Tests/TraceTests/SpecialTests.cs
@@ -35,8 +35,8 @@ namespace Tracer.Fody.Tests.TraceTests
 
             var testDllLocation = new Uri(Assembly.GetExecutingAssembly().CodeBase);
             var assemblyPath = Compile(code, "testasm", new[] { testDllLocation.AbsolutePath });
-            Rewrite(assemblyPath, new NullTraceLoggingFilter());
-            Rewrite(assemblyPath, new NullTraceLoggingFilter());
+            Rewrite(assemblyPath, new AllTraceLoggingFilter());
+            Rewrite(assemblyPath, new AllTraceLoggingFilter());
 
             var result = this.RunCode(assemblyPath, "First.MyClass", "Main");
 

--- a/Tracer.Fody/Filters/DefaultFilter.cs
+++ b/Tracer.Fody/Filters/DefaultFilter.cs
@@ -164,7 +164,6 @@ namespace Tracer.Fody.Filters
 
         public enum TraceTargetVisibility
         {
-            None = -1,
             Public = 0,
             InternalOrMoreVisible = 1,
             ProtectedOrMoreVisible = 2,
@@ -209,7 +208,6 @@ namespace Tracer.Fody.Filters
                     case "internal": return TraceTargetVisibility.InternalOrMoreVisible;
                     case "protected": return TraceTargetVisibility.ProtectedOrMoreVisible;
                     case "private": return TraceTargetVisibility.All;
-                    case "none": return TraceTargetVisibility.None;
                     default:
                         throw new ApplicationException(String.Format("Tracer: TraceOn config element attribute {0} has an invalid value {1}.", attributeName, attribute.Value));
                 }

--- a/Tracer.Fody/Filters/DefaultFilter.cs
+++ b/Tracer.Fody/Filters/DefaultFilter.cs
@@ -164,6 +164,7 @@ namespace Tracer.Fody.Filters
 
         public enum TraceTargetVisibility
         {
+            None = -1,
             Public = 0,
             InternalOrMoreVisible = 1,
             ProtectedOrMoreVisible = 2,
@@ -208,6 +209,7 @@ namespace Tracer.Fody.Filters
                     case "internal": return TraceTargetVisibility.InternalOrMoreVisible;
                     case "protected": return TraceTargetVisibility.ProtectedOrMoreVisible;
                     case "private": return TraceTargetVisibility.All;
+                    case "none": return TraceTargetVisibility.None;
                     default:
                         throw new ApplicationException(String.Format("Tracer: TraceOn config element attribute {0} has an invalid value {1}.", attributeName, attribute.Value));
                 }

--- a/Tracer.Fody/NuGet/Tracer.Fody.nuspec
+++ b/Tracer.Fody/NuGet/Tracer.Fody.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Tracer.Fody</id>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <authors>csnemes</authors>
     <owners>csnemes</owners>
     <projectUrl>https://github.com/csnemes/tracer</projectUrl>

--- a/Tracer.Fody/Properties/AssemblyInfo.cs
+++ b/Tracer.Fody/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
 [assembly: InternalsVisibleTo("Tracer.Fody.Tests")]

--- a/Tracer.Fody/Weavers/MethodReferenceProvider.cs
+++ b/Tracer.Fody/Weavers/MethodReferenceProvider.cs
@@ -37,6 +37,7 @@ namespace Tracer.Fody.Weavers
             logTraceLeaveMethod.HasThis = true; //instance method
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_moduleDefinition.TypeSystem.String));
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_moduleDefinition.TypeSystem.Int64));
+            logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_moduleDefinition.TypeSystem.Int64));
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_typeReferenceProvider.StringArray));
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_typeReferenceProvider.ObjectArray));
             return logTraceLeaveMethod;

--- a/Tracer.Fody/Weavers/MethodWeaver.cs
+++ b/Tracer.Fody/Weavers/MethodWeaver.cs
@@ -190,11 +190,9 @@ namespace Tracer.Fody.Weavers
             //build up Trace call
             instructions.Add(Instruction.Create(OpCodes.Ldsfld, _loggerProvider.StaticLogger));
             instructions.AddRange(LoadMethodNameOnStack());
-            //calculate ticks elapsed
-            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
+
             instructions.Add(Instruction.Create(OpCodes.Ldloc, _body.GetVariable("$startTick")));
-            instructions.Add(Instruction.Create(OpCodes.Sub));
-            //tick calc ends
+            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
 
             instructions.Add(Instruction.Create(OpCodes.Ldloc, paramNamesDef));
             instructions.Add(Instruction.Create(OpCodes.Ldloc, paramValuesDef));
@@ -240,11 +238,8 @@ namespace Tracer.Fody.Weavers
             //build up Trace call
             instructions.Add(Instruction.Create(OpCodes.Ldsfld, _loggerProvider.StaticLogger));
             instructions.AddRange(LoadMethodNameOnStack());
-            //calculate ticks elapsed
-            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
             instructions.Add(Instruction.Create(OpCodes.Ldloc, _body.GetVariable("$startTick")));
-            instructions.Add(Instruction.Create(OpCodes.Sub));
-            //tick calc ends
+            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
             instructions.Add(traceLeaveNeedsParamArray ? Instruction.Create(OpCodes.Ldloc, paramNamesDef) : Instruction.Create(OpCodes.Ldnull));
             instructions.Add(traceLeaveNeedsParamArray ? Instruction.Create(OpCodes.Ldloc, paramValuesDef) : Instruction.Create(OpCodes.Ldnull));
             instructions.Add(Instruction.Create(OpCodes.Callvirt, _methodReferenceProvider.GetTraceLeaveReference()));

--- a/Tracer.Fody/Weavers/MethodWeaver.cs
+++ b/Tracer.Fody/Weavers/MethodWeaver.cs
@@ -474,7 +474,7 @@ namespace Tracer.Fody.Weavers
         private IEnumerable<Instruction> LoadMethodNameOnStack()
         {
             var sb = new StringBuilder();
-            sb.Append(_methodDefinition.Name);
+            sb.Append(PrettyMethodName);
             sb.Append("(");
             for (int i = 0; i < _methodDefinition.Parameters.Count; i++)
             {
@@ -489,6 +489,16 @@ namespace Tracer.Fody.Weavers
             {
                 Instruction.Create(OpCodes.Ldstr, sb.ToString())
             };
+        }
+
+        private string PrettyMethodName
+        {
+            get
+            {
+                //check if method name is generated and prettyfy it
+                var position = _methodDefinition.Name.IndexOf(">", StringComparison.OrdinalIgnoreCase);
+                return position > 1 ? _methodDefinition.Name.Substring(1, position - 1) : _methodDefinition.Name;
+            }
         }
 
         internal interface ILoggerProvider

--- a/Tracer.Fody/Weavers/ModuleLevelWeaver.cs
+++ b/Tracer.Fody/Weavers/ModuleLevelWeaver.cs
@@ -59,18 +59,9 @@ namespace Tracer.Fody.Weavers
             var factory = new TypeWeaverFactory(_configuration.Filter, typeReferenceProvider, methodReferenceProvider);
             foreach (var type in _moduleDefinition.GetAllTypes())
             {
-                if (!HasCompilerGeneratedAttribute(type))
-                {
-                    var weaver = factory.Create(type);
-                    weaver.Execute();
-                }
+                var weaver = factory.Create(type);
+                weaver.Execute();
             }
-        }
-
-        private bool HasCompilerGeneratedAttribute(TypeDefinition type)
-        {
-            return type.HasCustomAttributes && type.CustomAttributes.
-                Any(attr => attr.AttributeType.FullName.Equals(typeof(CompilerGeneratedAttribute).FullName, StringComparison.Ordinal));
         }
 
         private IMetadataScope _loggerScope;

--- a/Tracer.Fody/packages.config
+++ b/Tracer.Fody/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FodyCecil" version="1.28.3" targetFramework="net40" developmentDependency="true" />
+  <package id="FodyCecil" version="1.28.3" targetFramework="net4" developmentDependency="true" />
 </packages>

--- a/Tracer.Log4net/Adapters/LoggerAdapter.cs
+++ b/Tracer.Log4net/Adapters/LoggerAdapter.cs
@@ -60,7 +60,7 @@ namespace Tracer.Log4Net.Adapters
             }
         }
 
-        public void TraceLeave(string methodInfo, long numberOfTicks, string[] paramNames, object[] paramValues)
+        public void TraceLeave(string methodInfo, long startTicks, long endTicks, string[] paramNames, object[] paramValues)
         {
             if (_logger.IsEnabledFor(Level.Trace))
             {
@@ -80,7 +80,9 @@ namespace Tracer.Log4Net.Adapters
                     propDict["arguments"] = returnValue;
                 }
 
-                var timeTaken = ConvertTicksToMilliseconds(numberOfTicks);
+                var timeTaken = ConvertTicksToMilliseconds(endTicks - startTicks);
+                propDict["startTicks"] = startTicks;
+                propDict["endTicks"] = endTicks;
                 propDict["timeTaken"] = timeTaken;
 
                 Log(Level.Trace, methodInfo,


### PR DESCRIPTION
...instead of just the duration of the call. For long running programs,
it is essential to have start and end times. However, since timeTaken is
still being stored in the PropertyDictionary it should not affect any
existing log4net config files that depend on this property.

Revert "Allow turning off Tracing in FodyWeavers.xml (assembly level)"