### PR TITLE
Allows users to turn off Tracing at the assembly level. This is impor…

### DIFF
--- a/Tracer.Fody/Filters/DefaultFilter.cs
+++ b/Tracer.Fody/Filters/DefaultFilter.cs
@@ -164,6 +164,7 @@ namespace Tracer.Fody.Filters
 
         public enum TraceTargetVisibility
         {
+            None = -1,
             Public = 0,
             InternalOrMoreVisible = 1,
             ProtectedOrMoreVisible = 2,
@@ -208,6 +209,7 @@ namespace Tracer.Fody.Filters
                     case "internal": return TraceTargetVisibility.InternalOrMoreVisible;
                     case "protected": return TraceTargetVisibility.ProtectedOrMoreVisible;
                     case "private": return TraceTargetVisibility.All;
+                    case "none": return TraceTargetVisibility.None;
                     default:
                         throw new ApplicationException(String.Format("Tracer: TraceOn config element attribute {0} has an invalid value {1}.", attributeName, attribute.Value));
                 }


### PR DESCRIPTION
…tant for performance-critical assemblies that don't want to log anything except some chosen methods/classes.

PS: Sorry about the previously closed pull requests, a bad squash screwed everything up (+_+)