### PR TITLE
Add start and end times (in ticks) to MethodWeaver. This gives the us…

### DIFF
--- a/Tracer.Fody/Weavers/MethodReferenceProvider.cs
+++ b/Tracer.Fody/Weavers/MethodReferenceProvider.cs
@@ -37,6 +37,7 @@ namespace Tracer.Fody.Weavers
             logTraceLeaveMethod.HasThis = true; //instance method
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_moduleDefinition.TypeSystem.String));
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_moduleDefinition.TypeSystem.Int64));
+            logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_moduleDefinition.TypeSystem.Int64));
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_typeReferenceProvider.StringArray));
             logTraceLeaveMethod.Parameters.Add(new ParameterDefinition(_typeReferenceProvider.ObjectArray));
             return logTraceLeaveMethod;

--- a/Tracer.Fody/Weavers/MethodWeaver.cs
+++ b/Tracer.Fody/Weavers/MethodWeaver.cs
@@ -190,11 +190,11 @@ namespace Tracer.Fody.Weavers
             //build up Trace call
             instructions.Add(Instruction.Create(OpCodes.Ldsfld, _loggerProvider.StaticLogger));
             instructions.AddRange(LoadMethodNameOnStack());
-            //calculate ticks elapsed
-            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
+            
+            //start ticks
             instructions.Add(Instruction.Create(OpCodes.Ldloc, _body.GetVariable("$startTick")));
-            instructions.Add(Instruction.Create(OpCodes.Sub));
-            //tick calc ends
+            //end ticks
+            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
 
             instructions.Add(Instruction.Create(OpCodes.Ldloc, paramNamesDef));
             instructions.Add(Instruction.Create(OpCodes.Ldloc, paramValuesDef));
@@ -240,11 +240,12 @@ namespace Tracer.Fody.Weavers
             //build up Trace call
             instructions.Add(Instruction.Create(OpCodes.Ldsfld, _loggerProvider.StaticLogger));
             instructions.AddRange(LoadMethodNameOnStack());
-            //calculate ticks elapsed
-            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
+            
+            //start ticks
             instructions.Add(Instruction.Create(OpCodes.Ldloc, _body.GetVariable("$startTick")));
-            instructions.Add(Instruction.Create(OpCodes.Sub));
-            //tick calc ends
+            //end ticks
+            instructions.Add(Instruction.Create(OpCodes.Call, _methodReferenceProvider.GetTimestampReference()));
+            
             instructions.Add(traceLeaveNeedsParamArray ? Instruction.Create(OpCodes.Ldloc, paramNamesDef) : Instruction.Create(OpCodes.Ldnull));
             instructions.Add(traceLeaveNeedsParamArray ? Instruction.Create(OpCodes.Ldloc, paramValuesDef) : Instruction.Create(OpCodes.Ldnull));
             instructions.Add(Instruction.Create(OpCodes.Callvirt, _methodReferenceProvider.GetTraceLeaveReference()));

--- a/Tracer.Log4net/Adapters/LoggerAdapter.cs
+++ b/Tracer.Log4net/Adapters/LoggerAdapter.cs
@@ -89,6 +89,37 @@ namespace Tracer.Log4Net.Adapters
             }
         }
 
+        public void TraceLeave(string methodInfo, long startTicks, long endTicks, string[] paramNames, object[] paramValues)
+        {
+            if (_logger.IsEnabledFor(Level.Trace))
+            {
+                var propDict = new PropertiesDictionary();
+                propDict["trace"] = "LEAVE";
+
+                string returnValue = null;
+                if (paramNames != null)
+                {
+                    var parameters = new StringBuilder();
+                    for (int i = 0; i < paramNames.Length; i++)
+                    {
+                        parameters.AppendFormat("{0}={1}", paramNames[i] ?? "$return", GetRenderedFormat(paramValues[i], NullString));
+                        if (i < paramNames.Length - 1) parameters.Append(", ");
+                    }
+                    returnValue = parameters.ToString();
+                    propDict["arguments"] = returnValue;
+                }
+
+                var timeTaken = ConvertTicksToMilliseconds(endTicks - startTicks);
+                propDict["startTicks"] = startTicks;
+                propDict["endTicks"] = endTicks;
+                propDict["timeTaken"] = timeTaken;
+
+                Log(Level.Trace, methodInfo,
+                    String.Format("Returned from {1} ({2}). Time taken: {0:0.00} ms.",
+                        timeTaken, methodInfo, returnValue), null, propDict);
+            }
+        }
+
         #endregion
 
         #region ILog methods


### PR DESCRIPTION
…tant for performance-critical assemblies that don't want to log anything except some chosen methods/classes.

PS: Sorry about the previously closed pull requests, a bad squash screwed everything up (+_+)