### PR TITLE
changed to primitive type value logging only to get rid of problems f…

### DIFF
--- a/Tracer.Log4net/Adapters/LoggerAdapter.cs
+++ b/Tracer.Log4net/Adapters/LoggerAdapter.cs
@@ -428,26 +428,21 @@ namespace Tracer.Log4Net.Adapters
         {
             if (message == null)
             {
-                return stringRepresentationOfNull;
+              return stringRepresentationOfNull;
             }
-            else if (message is string)
+
+            var type = message.GetType();
+            if (message is string)
             {
-                return message as string;
+              return message as string;
             }
-            else if (message is IEnumerator)
+            else if (type.IsPrimitive && _logger.Repository != null)
             {
-                var retVal = _logger.Repository.RendererMap.FindAndRender(message);
-                var enumerable = message as IEnumerator;
-                enumerable.Reset();
-                return retVal;
-            }
-            else if (_logger.Repository != null)
-            {
-                return _logger.Repository.RendererMap.FindAndRender(message);
+              return _logger.Repository.RendererMap.FindAndRender(message);
             }
             else
             {
-                return message.ToString();
+              return type.Name;
             }
         }
 


### PR DESCRIPTION
…or IEnumerable and IDBContext (Reading does not reset enumerator / missing data in reader itself after logging)

#23 does not seems to be the end of problems related to the tracing. I am now facing problems related to the IDataRecord interface. So Tracer gets the value and it is gone for the execution of the method itself. 

I have changed the behavior to primitve data logging only, i dont know if this is sufficent but for us it seems to be currently the best solution. I am not sure how to get a enumeration value logged but this is better than lost data of an IDBContext e.g.